### PR TITLE
update PNP for new Scala DyNet bindings

### DIFF
--- a/src/main/scala/org/allenai/dqa/labeling/DiagramFeatures.scala
+++ b/src/main/scala/org/allenai/dqa/labeling/DiagramFeatures.scala
@@ -3,8 +3,6 @@ package org.allenai.dqa.labeling
 import scala.io.Source
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.DyNetScalaHelpers._
-import edu.cmu.dynet.dynet_swig._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -17,12 +15,12 @@ case class DiagramFeatures(imageId: String, pointFeatures: Map[Point, FloatVecto
     pointFeatures(part.coords)
   }
 
-  def getFeatureMatrix(parts: Seq[Part], cg: ComputationGraph): Array[Expression] = {
+  def getFeatureMatrix(parts: Seq[Part]): Array[Expression] = {
     val expressions = for {
       part <- parts
     } yield {
       val features = getFeatures(part)
-      input(cg, Seq(features.size().asInstanceOf[Int]), features)
+      Expression.input(Dim(features.size), features)
     }
 
     expressions.toArray

--- a/src/main/scala/org/allenai/dqa/labeling/LabelingDqaCli.scala
+++ b/src/main/scala/org/allenai/dqa/labeling/LabelingDqaCli.scala
@@ -10,7 +10,7 @@ import com.jayantkrish.jklol.ccg.lambda2.SimplificationComparator
 import com.jayantkrish.jklol.cli.AbstractCli
 import com.jayantkrish.jklol.util.IndexedList
 
-import edu.cmu.dynet.dynet_swig._
+import edu.cmu.dynet._
 import joptsimple.OptionParser
 import joptsimple.OptionSet
 import joptsimple.OptionSpec
@@ -21,11 +21,8 @@ import org.allenai.pnp.Env
 import org.allenai.pnp.Pnp
 import com.jayantkrish.jklol.training.DefaultLogFunction
 import org.allenai.pnp.LoglikelihoodTrainer
-import edu.cmu.dynet.SimpleSGDTrainer
 import org.allenai.pnp.semparse.ActionSpace
 import com.google.common.collect.HashMultimap
-import edu.cmu.dynet.ComputationGraph
-import edu.cmu.dynet.DynetParams
 
 class LabelingDqaCli extends AbstractCli {
   
@@ -40,7 +37,7 @@ class LabelingDqaCli extends AbstractCli {
   }
   
   override def run(options: OptionSet): Unit = {
-    initialize(new DynetParams())
+    Initialize.initialize()
   
     // Initialize expression processing for logical forms. 
     val typeDeclaration = ExplicitTypeDeclaration.getDefault
@@ -104,10 +101,9 @@ class LabelingDqaCli extends AbstractCli {
   
   def validateParser(examples: Seq[PreprocessedLabelingExample], parser: SemanticParser): Unit = {
     for (ex <- examples) {
-      val cg = ComputationGraph.getNew
-      
+      ComputationGraph.renew()
       val lfDist = parser.generateExpression(ex.tokenIds, ex.entityLinking)
-      val dist = lfDist.beamSearch(100, 100, Env.init, null, parser.model.getComputationGraph(cg), null)
+      val dist = lfDist.beamSearch(100, 100, Env.init, null, parser.model.getComputationGraph(), null)
       println(ex.ex.tokens.mkString(" "))
       for (x <- dist.executions) {
         println("  "  + x)
@@ -137,10 +133,9 @@ class LabelingDqaCli extends AbstractCli {
       model: PnpModel): Unit = {
     var numCorrect = 0 
     for (ex <- examples) {
-      val cg = ComputationGraph.getNew
-
+      ComputationGraph.renew()
       val pp = p3.exampleToPnpExample(ex).unconditional
-      val dist = pp.beamSearch(100, 100, Env.init, null, model.getComputationGraph(cg), null)
+      val dist = pp.beamSearch(100, 100, Env.init, null, model.getComputationGraph(), null)
 
       println(ex.ex.tokens.mkString(" "))
       println(ex.ex.answerOptions)

--- a/src/main/scala/org/allenai/dqa/matching/MatchingModel.scala
+++ b/src/main/scala/org/allenai/dqa/matching/MatchingModel.scala
@@ -7,7 +7,7 @@ import org.allenai.pnp.Pnp.computationGraph
 import org.allenai.pnp.PnpModel
 
 import edu.cmu.dynet._
-import Utilities.RichNumeric
+import Utilities.NumbersAsExpressions
 
 import org.allenai.pnp.ExecutionScore
 import com.google.common.base.Preconditions

--- a/src/main/scala/org/allenai/dqa/matching/MatchingModel.scala
+++ b/src/main/scala/org/allenai/dqa/matching/MatchingModel.scala
@@ -102,7 +102,7 @@ class MatchingModel(val featureDim: Int, val matchIndependent: Boolean,
           scoreBinaryFactor(prevToCurSource, prevToCurTarget, compGraph)
         }
 
-        Expression.sum(new ExpressionVector(pairwiseScores))
+        pairwiseScores.foldLeft(Expression.input(0))(_ + _)
       }
 
       unaryScores.zip(binaryScores).map(x => x._1 + x._2)

--- a/src/main/scala/org/allenai/dqa/matching/MatchingModel.scala
+++ b/src/main/scala/org/allenai/dqa/matching/MatchingModel.scala
@@ -7,7 +7,7 @@ import org.allenai.pnp.Pnp.computationGraph
 import org.allenai.pnp.PnpModel
 
 import edu.cmu.dynet._
-import Utilities.NumbersAsExpressions
+import Expression.ImplicitNumerics
 
 import org.allenai.pnp.ExecutionScore
 import com.google.common.base.Preconditions

--- a/src/main/scala/org/allenai/dqa/matching/TrainMatchingCli.scala
+++ b/src/main/scala/org/allenai/dqa/matching/TrainMatchingCli.scala
@@ -15,7 +15,6 @@ import com.jayantkrish.jklol.training.DefaultLogFunction
 import com.jayantkrish.jklol.util.Pseudorandom
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 import joptsimple.OptionParser
 import joptsimple.OptionSet
 import joptsimple.OptionSpec
@@ -42,8 +41,7 @@ class TrainMatchingCli extends AbstractCli {
   }
 
   override def run(options: OptionSet): Unit = {
-    initialize(new DynetParams())
-    
+    Initialize.initialize()
     // Read and preprocess data
     val diagramFeatures = DiagramFeatures.fromJsonFile(options.valueOf(diagramFeaturesOpt)).map(
         x => (x.imageId, x)).toMap

--- a/src/main/scala/org/allenai/pnp/CompGraph.scala
+++ b/src/main/scala/org/allenai/pnp/CompGraph.scala
@@ -3,11 +3,10 @@ package org.allenai.pnp
 import com.jayantkrish.jklol.util.IndexedList
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 
 /** Computation graph of a neural network.
   */
-class CompGraph(val cg: ComputationGraph, val model: Model,
+class CompGraph(val model: Model,
     val paramNames: Map[String, Parameter], val lookupParamNames: Map[String, LookupParameter], 
     val locallyNormalized: Boolean) {
   
@@ -15,7 +14,7 @@ class CompGraph(val cg: ComputationGraph, val model: Model,
   // parameter.
   val paramExpressions = new Array[Expression](paramNames.size)
   for (i <- 0 until paramNames.size) {
-    paramExpressions(i) = parameter(cg, new Parameter(model, i)) 
+    paramExpressions(i) = Expression.parameter(new Parameter(model, i))
   }
 
   def getParameter(name: String): Parameter = {
@@ -28,8 +27,8 @@ class CompGraph(val cg: ComputationGraph, val model: Model,
 }
 
 object CompGraph {
-  def empty(cg: ComputationGraph, model: Model): CompGraph = {
-    new CompGraph(cg, model, Map(), Map(), false)
+  def empty(model: Model): CompGraph = {
+    new CompGraph(model, Map(), Map(), false)
   }
 }
 

--- a/src/main/scala/org/allenai/pnp/Env.scala
+++ b/src/main/scala/org/allenai/pnp/Env.scala
@@ -4,7 +4,6 @@ import com.jayantkrish.jklol.util.IndexedList
 import com.jayantkrish.jklol.training.LogFunction
 import com.jayantkrish.jklol.training.NullLogFunction
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 
 /** Mutable global state of a neural probabilistic program
   * execution. Env also tracks the chosen values for any
@@ -19,8 +18,6 @@ class Env(val labels: List[Int], val labelNodeIds: List[Expression],
     varnames: IndexedList[String], vars: Array[AnyRef],
     val activeTimers: Set[String], val log: LogFunction) {
 
-  import DyNetScalaHelpers._
-  
   /** Get the value of the named variable as an instance
     * of type A.
     */
@@ -78,13 +75,13 @@ class Env(val labels: List[Int], val labelNodeIds: List[Expression],
     * the score is computed by summing the negative log-softmax
     * scores of each choice.
     */
-  def getScore(normalize: Boolean, cg: ComputationGraph): Expression = {
-    var exScore = input(cg, 0)
+  def getScore(normalize: Boolean): Expression = {
+    var exScore = Expression.input(0)
     for ((expr, labelInd) <- labelNodeIds.zip(labels)) {
       val decisionScore = if (normalize) {
-        pickneglogsoftmax(expr, labelInd)
+        Expression.pickNegLogSoftmax(expr, labelInd)
       } else {
-        pick(expr, labelInd)
+        Expression.pick(expr, labelInd)
       }
       exScore = exScore + decisionScore
     }

--- a/src/main/scala/org/allenai/pnp/LoglikelihoodTrainer.scala
+++ b/src/main/scala/org/allenai/pnp/LoglikelihoodTrainer.scala
@@ -7,25 +7,22 @@ import com.google.common.base.Preconditions
 import com.jayantkrish.jklol.training.LogFunction
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 
 class LoglikelihoodTrainer(val epochs: Int, val beamSize: Int, val sumMultipleExecutions: Boolean,
     val model: PnpModel, val trainer: Trainer, val log: LogFunction) {
 
   Preconditions.checkArgument(model.locallyNormalized == true)
-  
-  import DyNetScalaHelpers._
-  
+
   def train[A](examples: Seq[PnpExample[A]]): Unit = {
     for (i <- 0 until epochs) {
       var loss = 0.0
       var searchErrors = 0
       log.notifyIterationStart(i)
       for (example <- examples) {
-        val cg = ComputationGraph.getNew
-       
+        ComputationGraph.renew()
+
         val env = example.env
-        val graph = model.getComputationGraph(cg)
+        val graph = model.getComputationGraph()
 
         // Compute the distribution over correct executions.
         log.startTimer("pp_loglikelihood/forward")
@@ -34,7 +31,7 @@ class LoglikelihoodTrainer(val epochs: Int, val beamSize: Int, val sumMultipleEx
         log.stopTimer("pp_loglikelihood/forward")
         
         log.startTimer("pp_loglikelihood/build_loss")
-        val exLosses = conditional.executions.map(_.env.getScore(true, cg))
+        val exLosses = conditional.executions.map(_.env.getScore(true))
         
         val lossExpr = if (exLosses.length == 0) {
           Preconditions.checkState(sumMultipleExecutions,
@@ -52,18 +49,18 @@ class LoglikelihoodTrainer(val epochs: Int, val beamSize: Int, val sumMultipleEx
               "Found %s conditional executions (expected exactly 1) for example: %s",
               conditional.executions.size.asInstanceOf[AnyRef], example)
 
-          logsumexp(new ExpressionVector(exLosses.toList.asJava))
+          Expression.logSumExp(new ExpressionVector(exLosses))
         }
         log.stopTimer("pp_loglikelihood/build_loss")
         
         if (lossExpr != null) {
           log.startTimer("pp_loglikelihood/eval_loss")
-          loss += as_scalar(cg.incremental_forward(lossExpr))
+          loss += ComputationGraph.incrementalForward(lossExpr).toFloat
           log.stopTimer("pp_loglikelihood/eval_loss")
 
           // cg.print_graphviz()
           log.startTimer("pp_loglikelihood/backward")
-          cg.backward(lossExpr)
+          ComputationGraph.backward(lossExpr)
           trainer.update(1.0f)
           log.stopTimer("pp_loglikelihood/backward")
         } else {
@@ -71,7 +68,7 @@ class LoglikelihoodTrainer(val epochs: Int, val beamSize: Int, val sumMultipleEx
         }
       }
 
-      trainer.update_epoch()
+      trainer.updateEpoch()
 
       log.logStatistic(i, "loss", loss)
       log.logStatistic(i, "search errors", searchErrors)

--- a/src/main/scala/org/allenai/pnp/PnpModel.scala
+++ b/src/main/scala/org/allenai/pnp/PnpModel.scala
@@ -15,13 +15,13 @@ class PnpModel(var names: Map[String, Parameter], var lookupNames: Map[String, L
     val model: Model, var locallyNormalized: Boolean) {
 
   def addParameter(name: String, dim: Dim): Parameter = {
-    val param = model.add_parameters(dim)
+    val param = model.addParameters(dim)
     names += (name -> param)
     param
   }
   
   def addLookupParameter(name: String, lookupNum: Long, dim: Dim): LookupParameter = {
-    val param = model.add_lookup_parameters(lookupNum, dim)
+    val param = model.addLookupParameters(lookupNum, dim)
     lookupNames += (name -> param)
     param
   }
@@ -34,24 +34,24 @@ class PnpModel(var names: Map[String, Parameter], var lookupNames: Map[String, L
     lookupNames(name)
   }
 
-  def getComputationGraph(cg: ComputationGraph): CompGraph = {
-    new CompGraph(cg, model, names, lookupNames, locallyNormalized)
+  def getComputationGraph(): CompGraph = {
+    new CompGraph(model, names, lookupNames, locallyNormalized)
   }
 
   def save(saver: ModelSaver): Unit = {
-    saver.add_model(model)
-    saver.add_boolean(locallyNormalized)
+    saver.addModel(model)
+    saver.addBoolean(locallyNormalized)
     
-    saver.add_int(names.size)
+    saver.addInt(names.size)
     for ((k, v) <- names) {
-      saver.add_object(k)
-      saver.add_parameter(v)
+      saver.addObject(k)
+      saver.addParameter(v)
     }
 
-    saver.add_int(lookupNames.size)
+    saver.addInt(lookupNames.size)
     for ((k, v) <- lookupNames) {
-      saver.add_object(k)
-      saver.add_lookup_parameter(v)
+      saver.addObject(k)
+      saver.addLookupParameter(v)
     }
   }
 }
@@ -62,22 +62,22 @@ object PnpModel {
   }
   
   def load(loader: ModelLoader): PnpModel = {
-    val model = loader.load_model()
-    val locallyNormalized = loader.load_boolean()
+    val model = loader.loadModel()
+    val locallyNormalized = loader.loadBoolean()
     
-    val numParams = loader.load_int()
+    val numParams = loader.loadInt()
     val params = ListBuffer[(String, Parameter)]()
     for (i <- 0 until numParams) {
-      val name = loader.load_object(classOf[String])
-      val param = loader.load_parameter()
+      val name = loader.loadObject(classOf[String])
+      val param = loader.loadParameter()
       params += ((name, param))
     }
 
-    val numLookups = loader.load_int()
+    val numLookups = loader.loadInt()
     val lookups = ListBuffer[(String, LookupParameter)]()
     for (i <- 0 until numLookups) {
-      val name = loader.load_object(classOf[String])
-      val param = loader.load_lookup_parameter()
+      val name = loader.loadObject(classOf[String])
+      val param = loader.loadLookupParameter()
       lookups += ((name, param))
     }
 

--- a/src/main/scala/org/allenai/pnp/examples/MultilayerPerceptron.scala
+++ b/src/main/scala/org/allenai/pnp/examples/MultilayerPerceptron.scala
@@ -2,7 +2,6 @@ package org.allenai.pnp.examples
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-
 import org.allenai.pnp.CompGraph
 import org.allenai.pnp.Env
 import org.allenai.pnp.ExecutionScore
@@ -12,11 +11,9 @@ import org.allenai.pnp.PnpModel
 
 import com.google.common.base.Preconditions
 import com.jayantkrish.jklol.util.IndexedList
-
 import edu.cmu.dynet._
-import edu.cmu.dynet.DyNetScalaHelpers._
-import edu.cmu.dynet.dynet_swig._
 import org.allenai.pnp.PnpExample
+
 import com.jayantkrish.jklol.training.NullLogFunction
 import org.allenai.pnp.BsoTrainer
 
@@ -39,8 +36,8 @@ object MultilayerPerceptron {
       bias1 <- param("layer1Bias")
       weights2 <- param("layer2Weights")
 
-      inputExpression = input(cg.cg, Seq(FEATURE_VECTOR_DIM), x)
-      scores = weights2 * tanh((weights1 * inputExpression) + bias1)
+      inputExpression = Expression.input(Dim(FEATURE_VECTOR_DIM), x)
+      scores = weights2 * Expression.tanh((weights1 * inputExpression) + bias1)
 
       y <- choose(Array(true, false), scores)
     } yield {
@@ -51,10 +48,10 @@ object MultilayerPerceptron {
   def labelNn(left: Boolean, right: Boolean, cg: CompGraph): Expression = {
     val leftParam = cg.getLookupParameter("left")
     val rightParam = cg.getLookupParameter("right")
-    val leftVec = lookup(cg.cg, leftParam, if (left) { 0 } else { 1 })
-    val rightVec = lookup(cg.cg, rightParam, if (right) { 0 } else { 1 })
+    val leftVec = Expression.lookup(leftParam, if (left) { 0 } else { 1 })
+    val rightVec = Expression.lookup(rightParam, if (right) { 0 } else { 1 })
     
-    dot_product(leftVec, rightVec)
+    Expression.dotProduct(leftVec, rightVec)
   }
   
   def sequenceTag(xs: Seq[FloatVector]): Pnp[List[Boolean]] = {
@@ -75,14 +72,14 @@ object MultilayerPerceptron {
 
   def main(args: Array[String]): Unit = {
     // Initialize dynet
-    initialize(new DynetParams())
+    Initialize.initialize()
 
     val model = PnpModel.init(true)
-    model.addParameter("layer1Weights", Seq(HIDDEN_DIM, FEATURE_VECTOR_DIM))
-    model.addParameter("layer1Bias", Seq(HIDDEN_DIM))
-    model.addParameter("layer2Weights", Seq(2, HIDDEN_DIM))
+    model.addParameter("layer1Weights", Dim(HIDDEN_DIM, FEATURE_VECTOR_DIM))
+    model.addParameter("layer1Bias", Dim(HIDDEN_DIM))
+    model.addParameter("layer2Weights", Dim(2, HIDDEN_DIM))
     
-    val featureVector = new FloatVector(Seq(1.0f, 2, 3))
+    val featureVector = new FloatVector(Seq(1.0f, 2f, 3f))
     val dist = mlp(featureVector)
     val marginals = dist.beamSearch(2, model)
  
@@ -93,8 +90,8 @@ object MultilayerPerceptron {
     val featureVectors = Seq(featureVector, featureVector, featureVector)
     
     model.locallyNormalized = false
-    model.addLookupParameter("left", 2, Seq(LABEL_DIM))
-    model.addLookupParameter("right", 2, Seq(LABEL_DIM))
+    model.addLookupParameter("left", 2, Dim(LABEL_DIM))
+    model.addLookupParameter("right", 2, Dim(LABEL_DIM))
     val dist2 = sequenceTag(featureVectors)
     val marginals2 = dist2.beamSearch(5, model)
     for (x <- marginals2.executions) {

--- a/src/main/scala/org/allenai/pnp/examples/Seq2Seq.scala
+++ b/src/main/scala/org/allenai/pnp/examples/Seq2Seq.scala
@@ -14,8 +14,6 @@ import com.google.common.base.Preconditions
 import com.jayantkrish.jklol.util.IndexedList
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.DyNetScalaHelpers._
-import edu.cmu.dynet.dynet_swig._
 import org.allenai.pnp.PnpExample
 import com.jayantkrish.jklol.training.NullLogFunction
 import org.allenai.pnp.BsoTrainer
@@ -27,7 +25,7 @@ import org.allenai.pnp.BsoTrainer
  * from the source LSTM. 
  */
 class Seq2Seq[S, T](val sourceVocab: IndexedList[S], val targetVocab: IndexedList[T],
-    val endTokenIndex: Int, forwardBuilder: LSTMBuilder, outputBuilder: LSTMBuilder,
+    val endTokenIndex: Int, forwardBuilder: LstmBuilder, outputBuilder: LstmBuilder,
     val model: PnpModel) {
 
   var dropoutProb = -1.0
@@ -50,7 +48,7 @@ class Seq2Seq[S, T](val sourceVocab: IndexedList[S], val targetVocab: IndexedLis
       inputEncoding = rnnEncode(cg, sourceTokens)
       
       // Initialize the output LSTM
-      _ = outputBuilder.start_new_sequence(inputEncoding)
+      _ = outputBuilder.startNewSequence(inputEncoding)
       startRnnState = outputBuilder.state()
       startInput <- param(TARGET_START_INPUT)
 
@@ -77,9 +75,8 @@ class Seq2Seq[S, T](val sourceVocab: IndexedList[S], val targetVocab: IndexedLis
   }
 
   private def initializeRnns(computationGraph: CompGraph): Unit = {
-    val cg = computationGraph.cg
-    forwardBuilder.new_graph(cg)
-    outputBuilder.new_graph(cg)
+    forwardBuilder.newGraph()
+    outputBuilder.newGraph()
   }
 
   /**
@@ -87,24 +84,22 @@ class Seq2Seq[S, T](val sourceVocab: IndexedList[S], val targetVocab: IndexedLis
    * the LSTM's state.  
    */
   private def rnnEncode(computationGraph: CompGraph, tokens: Seq[Int]): ExpressionVector = {
-    val cg = computationGraph.cg
-    
     val wordEmbeddings = computationGraph.getLookupParameter(SOURCE_EMBEDDINGS)
-    val inputEmbeddings = tokens.map(x => lookup(cg, wordEmbeddings, x)).toArray
+    val inputEmbeddings = tokens.map(x => Expression.lookup(wordEmbeddings, x)).toArray
     
-    forwardBuilder.start_new_sequence()
+    forwardBuilder.startNewSequence()
     val fwOutputs = ListBuffer[Expression]()
     for (inputEmbedding <- inputEmbeddings) {
-      val fwOutput = forwardBuilder.add_input(inputEmbedding)
+      val fwOutput = forwardBuilder.addInput(inputEmbedding)
       val fwOutputDropout = if (dropoutProb > 0.0) {
-        dropout(fwOutput, dropoutProb.asInstanceOf[Float])
+        Expression.dropout(fwOutput, dropoutProb.asInstanceOf[Float])
       } else {
         fwOutput
       }
       fwOutputs += fwOutputDropout
     }
     
-    return forwardBuilder.final_s
+    return forwardBuilder.finalS
   }
 
   /**
@@ -113,7 +108,7 @@ class Seq2Seq[S, T](val sourceVocab: IndexedList[S], val targetVocab: IndexedLis
    */
   private def generateTargetTokens(tokenIndex: Int, state: Int, curInput: Expression): Pnp[List[Int]] = {
     // Run one step of the LSTM to get the next state and output. 
-    val lstmOutput = outputBuilder.add_input(state, curInput)
+    val lstmOutput = outputBuilder.addInput(state, curInput)
     val nextState = outputBuilder.state
     
     for {
@@ -131,7 +126,7 @@ class Seq2Seq[S, T](val sourceVocab: IndexedList[S], val targetVocab: IndexedLis
       // is necessary to generate the next target.
       cg <- computationGraph()
       outputTokenLookups = cg.getLookupParameter(TARGET_EMBEDDINGS)
-      outputTokenEmbedding = lookup(cg.cg, outputTokenLookups, targetTokenIndex)
+      outputTokenEmbedding = Expression.lookup(outputTokenLookups, targetTokenIndex)
       
       v <- if (targetTokenIndex == endTokenIndex) {
         // If we chose the end of sequence token, we're done.
@@ -199,14 +194,14 @@ object Seq2Seq {
     val hiddenDim = 100
     val targetDim = 100
     
-    model.addLookupParameter(SOURCE_EMBEDDINGS, sourceVocab.size, Seq(sourceDim))
-    model.addLookupParameter(TARGET_EMBEDDINGS, targetVocab.size, Seq(targetDim))
+    model.addLookupParameter(SOURCE_EMBEDDINGS, sourceVocab.size, Dim(sourceDim))
+    model.addLookupParameter(TARGET_EMBEDDINGS, targetVocab.size, Dim(targetDim))
     
-    model.addParameter(TARGET_START_INPUT, Seq(targetDim))
-    model.addParameter(TARGET_WEIGHTS, Seq(targetVocab.size, hiddenDim))
+    model.addParameter(TARGET_START_INPUT, Dim(targetDim))
+    model.addParameter(TARGET_WEIGHTS, Dim(targetVocab.size, hiddenDim))
     
-    val sourceBuilder = new LSTMBuilder(1, sourceDim, hiddenDim, model.model)
-    val targetBuilder = new LSTMBuilder(1, targetDim, hiddenDim, model.model)
+    val sourceBuilder = new LstmBuilder(1, sourceDim, hiddenDim, model.model)
+    val targetBuilder = new LstmBuilder(1, targetDim, hiddenDim, model.model)
     
     new Seq2Seq(sourceVocab, targetVocab, endTokenIndex, sourceBuilder, targetBuilder, model) 
   }
@@ -216,7 +211,7 @@ object Seq2Seq {
     // sequence-to-sequence
     
     // Initialize dynet
-    initialize(new DynetParams())
+    Initialize.initialize()
     
     // Random parameters here
     val beamSize = 5
@@ -281,8 +276,8 @@ object Seq2Seq {
     
     // 4. Apply the trained model to new data.
     for (d <- testDataTokenized) {
-      val cg = ComputationGraph.getNew
-      val graph = seq2seq.model.getComputationGraph(cg)
+      ComputationGraph.renew()
+      val graph = seq2seq.model.getComputationGraph()
 
       // Generate the probabilistic neural program over target
       // sequences, then run inference with the trained parameters

--- a/src/main/scala/org/allenai/pnp/semparse/SemanticParserUtils.scala
+++ b/src/main/scala/org/allenai/pnp/semparse/SemanticParserUtils.scala
@@ -17,13 +17,10 @@ import edu.cmu.dynet._
 
 object SemanticParserUtils {
   
-  val DYNET_PARAMS = { 
-    val d = new DynetParams()
-    d.setMem_descriptor("1024")
-    d
-  }
-  
-  
+  val DYNET_PARAMS = Map(
+    "dynet-mem" -> "1024"
+  )
+
   /**
    * Count the number of occurrences of each word type
    * in a collection of examples. 
@@ -105,9 +102,9 @@ object SemanticParserUtils {
 
       if (oracleOpt.isDefined) {
         val oracle = oracleOpt.get
-        val cg = ComputationGraph.getNew
+        ComputationGraph.renew()
         val results = dist.beamSearch(1, 50, Env.init, oracle,
-            parser.model.getComputationGraph(cg), new NullLogFunction())
+            parser.model.getComputationGraph(), new NullLogFunction())
         if (results.executions.size != 1) {
           println("ERROR: " + e + " " + results)
           println("  " + e.getSentence.getWords)

--- a/src/main/scala/org/allenai/pnp/semparse/TrainSemanticParserCli.scala
+++ b/src/main/scala/org/allenai/pnp/semparse/TrainSemanticParserCli.scala
@@ -26,7 +26,6 @@ import com.jayantkrish.jklol.training.NullLogFunction
 import com.jayantkrish.jklol.util.IndexedList
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 import joptsimple.OptionParser
 import joptsimple.OptionSet
 import joptsimple.OptionSpec
@@ -51,7 +50,7 @@ class TrainSemanticParserCli extends AbstractCli() {
   }
   
   override def run(options: OptionSet): Unit = {
-    initialize(SemanticParserUtils.DYNET_PARAMS)
+    Initialize.initialize(SemanticParserUtils.DYNET_PARAMS)
     
     // Initialize expression processing for Geoquery logical forms. 
     val typeDeclaration = GeoqueryUtil.getSimpleTypeDeclaration()

--- a/src/test/scala/org/allenai/pnp/BsoTrainerSpec.scala
+++ b/src/test/scala/org/allenai/pnp/BsoTrainerSpec.scala
@@ -10,12 +10,11 @@ import com.jayantkrish.jklol.training.NullLogFunction
 import com.jayantkrish.jklol.util.IndexedList
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 import com.jayantkrish.jklol.training.DefaultLogFunction
 
 class BsoTrainerSpec extends FlatSpec with Matchers {
   
-  initialize(new DynetParams())
+  Initialize.initialize()
   
   val TOLERANCE = 0.01
 
@@ -45,9 +44,9 @@ class BsoTrainerSpec extends FlatSpec with Matchers {
     val inputIndexes = input.split(" ").map(x => sourceVocab.getIndex(x)).toArray
     val expectedIndexes = expected.split(" ").map(x => targetVocab.getIndex(x)).toArray
     val unconditional = seq2seq.applyEncoded(inputIndexes)
-      
-    val cg = ComputationGraph.getNew
-    val graph = seq2seq.model.getComputationGraph(cg)
+
+    ComputationGraph.renew()
+    val graph = seq2seq.model.getComputationGraph()
 
     val marginals = unconditional.beamSearch(10, 10, Env.init, null, graph, new NullLogFunction)
     

--- a/src/test/scala/org/allenai/pnp/GlobalLoglikelihoodTrainerSpec.scala
+++ b/src/test/scala/org/allenai/pnp/GlobalLoglikelihoodTrainerSpec.scala
@@ -3,14 +3,12 @@ package org.allenai.pnp
 import scala.collection.JavaConverters._
 import org.scalatest._
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 import com.jayantkrish.jklol.util.IndexedList
 import com.jayantkrish.jklol.training.NullLogFunction
 
 class GlobalLoglikelihoodTrainerSpec extends FlatSpec with Matchers {
   
-  import DyNetScalaHelpers._
-  initialize(new DynetParams())
+  Initialize.initialize()
 
   val TOLERANCE = 0.01
 
@@ -30,7 +28,8 @@ class GlobalLoglikelihoodTrainerSpec extends FlatSpec with Matchers {
           rest <- lm(k - 1)
           previous = rest.last
           transition <- Pnp.param("transition")
-          params = pickrange(transition, previous * vocab.length, (previous + 1) * vocab.length)
+          params = Expression.pickrange(
+            transition, previous * vocab.length, (previous + 1) * vocab.length)
           choice <- Pnp.choose(vocab, params, k - 1)
         } yield {
           rest ++ Array(choice)
@@ -60,8 +59,8 @@ class GlobalLoglikelihoodTrainerSpec extends FlatSpec with Matchers {
     }
     
     val model = PnpModel.init(false)
-    val startParam = model.addParameter("start", Seq(vocab.length))
-    val transitionParam = model.addParameter("transition", Seq(vocab.length * vocab.length))
+    val startParam = model.addParameter("start", Dim(vocab.length))
+    val transitionParam = model.addParameter("transition", Dim(vocab.length * vocab.length))
 
     val examples = List(
         PnpExample(lm(3), lm(3), Env.init, makeOracle(Array(0,1,0))),

--- a/src/test/scala/org/allenai/pnp/LoglikelihoodTrainerSpec.scala
+++ b/src/test/scala/org/allenai/pnp/LoglikelihoodTrainerSpec.scala
@@ -3,15 +3,13 @@ package org.allenai.pnp
 import scala.collection.JavaConverters._
 import org.scalatest._
 import edu.cmu.dynet._
-import edu.cmu.dynet.DyNetScalaHelpers._
-import edu.cmu.dynet.dynet_swig._
 import com.jayantkrish.jklol.util.IndexedList
 import com.jayantkrish.jklol.training.NullLogFunction
 import scala.collection.mutable.ListBuffer
 
 class LoglikelihoodTrainerSpec extends FlatSpec with Matchers {
   
-  initialize(new DynetParams())
+  Initialize.initialize()
 
   val TOLERANCE = 0.01
   
@@ -29,8 +27,8 @@ class LoglikelihoodTrainerSpec extends FlatSpec with Matchers {
     trainer.train(examples)
 
     val env = Env.init
-    val computationGraph = ComputationGraph.getNew
-    val marginals = foo(1, null).beamSearch(100, env, model.getComputationGraph(computationGraph))
+    ComputationGraph.renew()
+    val marginals = foo(1, null).beamSearch(100, env, model.getComputationGraph())
     val values = marginals.executions
     val partitionFunction = marginals.partitionFunction
     values.length should be(2)
@@ -64,13 +62,14 @@ class LoglikelihoodTrainerSpec extends FlatSpec with Matchers {
     // Train model
     val sgd = new SimpleSGDTrainer(model.model, 0.1f, 0.01f)
     val trainer = new LoglikelihoodTrainer(1000, 100, false, model, sgd, new NullLogFunction())
+    println("about to train")
     trainer.train(examples)
 
     // Check that training error is zero.
     for (ex <- data) {
       val env = Env.init
-      val cg = ComputationGraph.getNew
-      val marginals = xor(ex._1, ex._2).beamSearch(100, env, model.getComputationGraph(cg))
+      ComputationGraph.renew()
+      val marginals = xor(ex._1, ex._2).beamSearch(100, env, model.getComputationGraph())
       val values = marginals.executions
       val partitionFunction = marginals.partitionFunction
 
@@ -78,7 +77,7 @@ class LoglikelihoodTrainerSpec extends FlatSpec with Matchers {
       (values(0).prob / partitionFunction) should be(1.0 +- 0.1)
     }
   }
-  
+
   it should "learn with multiple correct labels" in {
     val model = xorModel()
 
@@ -118,8 +117,9 @@ class LoglikelihoodTrainerSpec extends FlatSpec with Matchers {
     // Check that training error is zero.
     for (ex <- data) {
       val env = Env.init
-      val cg = ComputationGraph.getNew
-      val marginals = xor(ex._1, ex._2).beamSearch(100, env, model.getComputationGraph(cg))
+      ComputationGraph.renew()
+
+      val marginals = xor(ex._1, ex._2).beamSearch(100, env, model.getComputationGraph())
       val values = marginals.executions
       val partitionFunction = marginals.partitionFunction
 
@@ -160,7 +160,7 @@ object LoglikelihoodTrainerSpec {
   
   def fooModel(): PnpModel = {
     val model = PnpModel.init(true)
-    model.addParameter("flip", Seq(2))
+    model.addParameter("flip", Dim(2))
     model
   }
   
@@ -170,16 +170,16 @@ object LoglikelihoodTrainerSpec {
     values(0) = if (left) { 1 } else { 0 }
     values(1) = if (right) { 1 } else { 0 }
     val featureVector = new FloatVector(2)
-    featureVector.set(0, values(0))
-    featureVector.set(1, values(1))
+    featureVector.update(0, values(0))
+    featureVector.update(1, values(1))
     
     for {
       // Build a 2 layer neural network with a tanh
       // nonlinearity.
       params <- Pnp.param("params")
       bias <- Pnp.param("bias")
-      featureVectorExpression <- Pnp.constant(Seq(2), featureVector)
-      hidden = tanh((params * featureVectorExpression) + bias)
+      featureVectorExpression <- Pnp.constant(Dim(2), featureVector)
+      hidden = Expression.tanh((params * featureVectorExpression) + bias)
       params2 <- Pnp.param("params2")
       bias2 <- Pnp.param("bias2")
       dist = (params2 * hidden) + bias2
@@ -199,10 +199,10 @@ object LoglikelihoodTrainerSpec {
   def xorModel(): PnpModel = {
     // Initialize model parameters.
     val model = PnpModel.init(true)
-    model.addParameter("params", Seq(8, 2))
-    model.addParameter("bias", Seq(8))
-    model.addParameter("params2", Seq(2, 8))
-    model.addParameter("bias2", Seq(2))
+    model.addParameter("params", Dim(8, 2))
+    model.addParameter("bias", Dim(8))
+    model.addParameter("params2", Dim(2, 8))
+    model.addParameter("bias2", Dim(2))
 
     model
   }

--- a/src/test/scala/org/allenai/pnp/PnpSpec.scala
+++ b/src/test/scala/org/allenai/pnp/PnpSpec.scala
@@ -14,15 +14,13 @@ import com.jayantkrish.jklol.training.StochasticGradientTrainer
 import com.jayantkrish.jklol.util.IndexedList
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 import scala.collection.mutable.ListBuffer
 
 /** Test cases for the probabilistic programming monad.
   */
 class PnpSpec extends FlatSpec with Matchers {
 
-  import DyNetScalaHelpers._
-  initialize(new DynetParams())
+  Initialize.initialize()
 
   val TOLERANCE = 0.01
   
@@ -229,14 +227,12 @@ class PnpSpec extends FlatSpec with Matchers {
       }
     }
 
-    val computationGraph = ComputationGraph.getNew    
-
     val model = PnpModel.init(false)
-    val flipParam = model.addParameter("flip", Seq(2))
+    val flipParam = model.addParameter("flip", Dim(2))
     flipParam.zero()
     
     val env = Env.init
-    val cg = model.getComputationGraph(computationGraph)
+    val cg = model.getComputationGraph()
 
     val values = foo(1).beamSearch(100, env, cg).executions
     values.length should be(2)

--- a/src/test/scala/org/allenai/pnp/semparse/SemanticParserSpec.scala
+++ b/src/test/scala/org/allenai/pnp/semparse/SemanticParserSpec.scala
@@ -12,12 +12,11 @@ import com.jayantkrish.jklol.training.NullLogFunction
 import com.jayantkrish.jklol.util.IndexedList
 
 import edu.cmu.dynet._
-import edu.cmu.dynet.dynet_swig._
 import org.allenai.pnp.PnpModel
 
 class SemanticParserSpec extends FlatSpec with Matchers {
   
-  initialize(new DynetParams())
+  Initialize.initialize()
  
   val dataStrings = List(
       ("state", "state:<e,t>"),
@@ -57,8 +56,8 @@ class SemanticParserSpec extends FlatSpec with Matchers {
     val oracle = parser.generateExecutionOracle(label, entityLinking, typeDeclaration).get
     val exprs = parser.generateExpression(Array("major", "city").map(vocab.getIndex(_)), entityLinking)
 
-    val cg = ComputationGraph.getNew
-    val compGraph = parser.model.getComputationGraph(cg)
+    ComputationGraph.renew()
+    val compGraph = parser.model.getComputationGraph()
     
     val results = exprs.beamSearch(1, -1, Env.init, oracle, compGraph, new NullLogFunction()).executions
     for (result <- results) {


### PR DESCRIPTION
pretty straightforward. (I found a couple of missing Scala bindings, I'll send out a PR for those as well).

one thing to note: on my first pass I just deleted all of the `ComputationGraph.getNew` calls, and that causes all sort of errors in the C++ code. When I went back and replaced them with `ComputationGraph.renew()`, everything worked again. We should probably give guidance about when to call `renew()`, but I'm not 100% sure what that guidance is.

--

note: The following test fails, but it was failing before I made any changes.

```
[info] - should collapse inference *** FAILED ***
[info]   2 was not equal to 1 (PnpSpec.scala:128)
```