### PR TITLE
Fixing bugs 

### DIFF
--- a/experiments/wikitables/scripts/config.sh
+++ b/experiments/wikitables/scripts/config.sh
@@ -7,5 +7,9 @@ DERIVATIONS_PATH="data/wikitables/dpd_output/onedir2"
 EXPERIMENT_NAME="000"
 EXPERIMENT_DIR="experiments/wikitables/output/$EXPERIMENT_NAME/"
 
+EPOCHS=200
+MAX_TRAINING_DERIVATIONS=1
+BEAM_SIZE=5
+
 mkdir -p $EXPERIMENT_DIR
 

--- a/experiments/wikitables/scripts/run_experiment.sh
+++ b/experiments/wikitables/scripts/run_experiment.sh
@@ -9,7 +9,7 @@ MY_MODEL=$MY_DIR/model.ser
 mkdir -p $MY_DIR
 
 echo "Training $MY_NAME model..."
-./$SCRIPT_DIR/run.sh org.allenai.wikitables.WikiTablesSemanticParserCli -trainingData $TRAIN  -derivationsPath $DERIVATIONS_PATH --modelOut $MY_MODEL --skipActionSpaceValidation &> $MY_DIR/train_log.txt 
+./$SCRIPT_DIR/run.sh org.allenai.wikitables.WikiTablesSemanticParserCli --trainingData $TRAIN  --derivationsPath $DERIVATIONS_PATH --modelOut $MY_MODEL --epochs $EPOCHS --beamSize $BEAM_SIZE --maxDerivations $MAX_TRAINING_DERIVATIONS &> $MY_DIR/train_log.txt 
 
 echo "Evaluating $MY_NAME training error..."
-./$SCRIPT_DIR/run.sh org.allenai.wikitables.TestWikiTablesCli -testData $TRAIN  -derivationsPath $DERIVATIONS_PATH --model $MY_MODEL &> $MY_DIR/train_error_log.txt
+./$SCRIPT_DIR/run.sh org.allenai.wikitables.TestWikiTablesCli --testData $TRAIN  --derivationsPath $DERIVATIONS_PATH --model $MY_MODEL --beamSize $BEAM_SIZE &> $MY_DIR/train_error_log.txt

--- a/experiments/wikitables/scripts/run_experiment.sh
+++ b/experiments/wikitables/scripts/run_experiment.sh
@@ -9,7 +9,7 @@ MY_MODEL=$MY_DIR/model.ser
 mkdir -p $MY_DIR
 
 echo "Training $MY_NAME model..."
-./$SCRIPT_DIR/run.sh org.allenai.wikitables.WikiTablesSemanticParserCli --trainingData $TRAIN  --derivationsPath $DERIVATIONS_PATH --modelOut $MY_MODEL --epochs $EPOCHS --beamSize $BEAM_SIZE --maxDerivations $MAX_TRAINING_DERIVATIONS &> $MY_DIR/train_log.txt 
+# ./$SCRIPT_DIR/run.sh org.allenai.wikitables.WikiTablesSemanticParserCli --trainingData $TRAIN  --derivationsPath $DERIVATIONS_PATH --modelOut $MY_MODEL --epochs $EPOCHS --beamSize $BEAM_SIZE --maxDerivations $MAX_TRAINING_DERIVATIONS &> $MY_DIR/train_log.txt 
 
 echo "Evaluating $MY_NAME training error..."
-./$SCRIPT_DIR/run.sh org.allenai.wikitables.TestWikiTablesCli --testData $TRAIN  --derivationsPath $DERIVATIONS_PATH --model $MY_MODEL --beamSize $BEAM_SIZE &> $MY_DIR/train_error_log.txt
+./$SCRIPT_DIR/run.sh org.allenai.wikitables.TestWikiTablesCli --testData $TRAIN  --derivationsPath $DERIVATIONS_PATH --model $MY_MODEL --beamSize $BEAM_SIZE --evaluateDpd &> $MY_DIR/train_error_log.txt

--- a/src/main/java/org/allenai/wikitables/WikiTablesDataProcessor.java
+++ b/src/main/java/org/allenai/wikitables/WikiTablesDataProcessor.java
@@ -95,7 +95,7 @@ public class WikiTablesDataProcessor {
       if (ex.alternativeFormulas.size() > numDerivationsLimit) {
         List<Formula> derivations = ex.alternativeFormulas;
         derivations.sort(new DerivationLengthComparator());
-        ex.alternativeFormulas = derivations.subList(0, numDerivationsLimit - 1);
+        ex.alternativeFormulas = derivations.subList(0, numDerivationsLimit);
       }
       prunedDataset.add(ex);
     }

--- a/src/main/java/org/allenai/wikitables/WikiTablesDataProcessor.java
+++ b/src/main/java/org/allenai/wikitables/WikiTablesDataProcessor.java
@@ -11,12 +11,16 @@ import edu.stanford.nlp.sempre.corenlp.CoreNLPAnalyzer;
 import edu.stanford.nlp.sempre.FuzzyMatchFn.FuzzyMatchFnMode;
 import edu.stanford.nlp.sempre.tables.TableKnowledgeGraph;
 import edu.stanford.nlp.sempre.tables.StringNormalizationUtils;
+import edu.stanford.nlp.sempre.tables.TableValuePreprocessor;
 import edu.stanford.nlp.sempre.tables.dpd.DPDParser;
 import edu.stanford.nlp.sempre.tables.test.*;
 import edu.stanford.nlp.sempre.tables.match.*;
 import fig.basic.*;
 
 public class WikiTablesDataProcessor {
+  
+  private static Builder SEMPRE_BUILDER = getSempreBuilder(100);
+  
   public static List<CustomExample> getDataset(String path, boolean inSempreFormat,
                                                boolean includeDerivations, String derivationsPath,
                                                int beamSize, int numDerivationsLimit) {
@@ -249,12 +253,18 @@ public class WikiTablesDataProcessor {
   public static boolean isFormulaCorrect(Formula formula, ContextValue context, Value targetValue,
                                          Builder builder) {
     if (builder == null) {
-      // This can happen when we are
-      builder = getSempreBuilder(100);  // Beamsize does not matter.
+      builder = SEMPRE_BUILDER;
     }
+
     Value pred = builder.executor.execute(formula, context).value;
     if (pred instanceof ListValue)
       pred = ((TableKnowledgeGraph) context.graph).getListValueWithOriginalStrings((ListValue) pred);
+    
+    TableValuePreprocessor targetPreprocessor = new TableValuePreprocessor();
+    targetValue = targetPreprocessor.preprocess(targetValue);
+    // Print the predicted and target values.
+    // System.out.println(pred + " " + targetValue);
+
     double result = builder.valueEvaluator.getCompatibility(targetValue, pred);
     return result == 1;
   }

--- a/src/main/java/org/allenai/wikitables/WikiTablesExample.java
+++ b/src/main/java/org/allenai/wikitables/WikiTablesExample.java
@@ -42,9 +42,7 @@ public class WikiTablesExample {
   public boolean isFormulaCorrect(Expression2 pnpFormula) {
     // Sempre represents lambda expressions differently. We changed them when reading the examples. Changing
     // them back for execution.
-    System.out.println("Before conversion: " + pnpFormula.toString());
     String expressionString = WikiTablesUtil.toSempreLogicalForm(pnpFormula);
-    System.out.println("After conversion: " + expressionString);
     try {
       Formula sempreFormula = Formula.fromString(expressionString);
       return WikiTablesDataProcessor.isFormulaCorrect(sempreFormula, context, targetValue, null);

--- a/src/main/java/org/allenai/wikitables/WikiTablesUtil.java
+++ b/src/main/java/org/allenai/wikitables/WikiTablesUtil.java
@@ -8,9 +8,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.regex.Pattern;
 
+import com.google.common.collect.Lists;
+import com.jayantkrish.jklol.ccg.lambda.ExpressionParser;
 import com.jayantkrish.jklol.ccg.lambda2.Expression2;
+import com.jayantkrish.jklol.ccg.lambda2.ExpressionSimplifier;
 import com.jayantkrish.jklol.ccg.lambda2.StaticAnalysis;
+import com.jayantkrish.jklol.ccg.lambda2.VariableCanonicalizationReplacementRule;
 
 import edu.stanford.nlp.sempre.Formula;
 import edu.stanford.nlp.sempre.Formulas;
@@ -18,7 +23,7 @@ import edu.stanford.nlp.sempre.LambdaFormula;
 import fig.basic.LispTree;
 
 public class WikiTablesUtil {
-  public static String toPnpLogicalForm(Formula expression) {
+  public static Expression2 toPnpLogicalForm(Formula expression) {
     /*
     Sempre's lambda expressions are written differently from what pnp expects. We make the following changes
     1. Sempre uses ! and reverse interchangeably. Converting all ! to reverse.
@@ -32,8 +37,7 @@ public class WikiTablesUtil {
     // Change 1:
     expressionString = expressionString.replaceAll("!(fb:[^ ]*)", "(reverse $1)");
     LispTree expressionTree = expression.toLispTree();
-    if (expressionTree.isLeaf())
-      return expressionString;
+    
     Set<String> boundVariables = new HashSet<>();
     // BFS to find all the free variables
     Queue<LispTree> fringe = new LinkedList<>();
@@ -50,17 +54,21 @@ public class WikiTablesUtil {
         }
       }
     }
-    System.out.println(boundVariables);
     
     for (String variable: boundVariables) {
       expressionString = expressionString.replaceAll(String.format("lambda %s", variable),
                                                      String.format("lambda (%s)", variable));
       expressionString = expressionString.replaceAll(String.format("\\(var %s\\)", variable), variable);
     }
-    return expressionString;
+
+    return ExpressionParser.expression2().parse(expressionString);
   }
 
   public static String toSempreLogicalForm(Expression2 expression) {
+    ExpressionSimplifier simplifier = new ExpressionSimplifier(Lists.newArrayList(
+        new VariableCanonicalizationReplacementRule()));
+    expression = simplifier.apply(expression);
+    
     Queue<String> variableNames = new LinkedList<>(Arrays.asList("x", "y", "z"));
     for (char varName = 'a'; varName <= 'w'; varName++) {
       variableNames.add(String.valueOf(varName));
@@ -79,24 +87,25 @@ public class WikiTablesUtil {
       if (!StaticAnalysis.isLambda(currExpression))
         continue;
       for (String var : StaticAnalysis.getLambdaArguments(currExpression)) {
-        if (var.startsWith("$")) {
-          if (!variableMap.containsKey(var))
-            variableMap.put(var, variableNames.remove());
-        }
+        variableMap.put(var, variableNames.remove());
       }
     }
+    
     String expressionString = expression.toString();
     for (String var: variableMap.keySet()) {
       String variableName = variableMap.get(var);
-      expressionString = expressionString.replaceAll(String.format("lambda \\(\\%s\\)", var),
+      expressionString = expressionString.replaceAll(String.format("lambda \\(%s\\)", Pattern.quote(var)),
                                                      String.format("lambda %s", variableName));
-      expressionString = expressionString.replaceAll(String.format("\\%s", var),
+      expressionString = expressionString.replaceAll(String.format("%s", Pattern.quote(var)),
                                                      String.format("(var %s)", variableName));
 
+      /*
+      // XXX: test this
       // The last replacement can potentially lead to formulae like ((reverse fb:row.row.player) ((var x))))
       // with a single child in subtree with (var x). Fixing those.
       expressionString = expressionString.replaceAll(String.format("\\(\\(var %s\\)\\)", variableName),
                                                      String.format("(var %s)", variableName));
+       */
     }
     return expressionString;
   }

--- a/src/main/java/org/allenai/wikitables/WikiTablesUtil.java
+++ b/src/main/java/org/allenai/wikitables/WikiTablesUtil.java
@@ -55,7 +55,7 @@ public class WikiTablesUtil {
     for (String variable: boundVariables) {
       expressionString = expressionString.replaceAll(String.format("lambda %s", variable),
                                                      String.format("lambda (%s)", variable));
-      expressionString = expressionString.replaceAll(String.format("(var %s)", variable), variable);
+      expressionString = expressionString.replaceAll(String.format("\\(var %s\\)", variable), variable);
     }
     return expressionString;
   }

--- a/src/main/java/org/allenai/wikitables/WikiTablesUtil.java
+++ b/src/main/java/org/allenai/wikitables/WikiTablesUtil.java
@@ -1,10 +1,17 @@
 package org.allenai.wikitables;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 
-import com.jayantkrish.jklol.ccg.lambda.ExpressionParser;
 import com.jayantkrish.jklol.ccg.lambda2.Expression2;
 import com.jayantkrish.jklol.ccg.lambda2.StaticAnalysis;
+
 import edu.stanford.nlp.sempre.Formula;
 import edu.stanford.nlp.sempre.Formulas;
 import edu.stanford.nlp.sempre.LambdaFormula;
@@ -37,6 +44,8 @@ public class WikiTablesUtil {
         }
       }
     }
+    System.out.println(boundVariables);
+    
     for (String variable: boundVariables) {
       expressionString = expressionString.replaceAll(String.format("lambda %s", variable),
                                                      String.format("lambda (%s)", variable));
@@ -77,6 +86,7 @@ public class WikiTablesUtil {
                                                      String.format("lambda %s", variableName));
       expressionString = expressionString.replaceAll(String.format("\\%s", var),
                                                      String.format("(var %s)", variableName));
+
       // The last replacement can potentially lead to formulae like ((reverse fb:row.row.player) ((var x))))
       // with a single child in subtree with (var x). Fixing those.
       expressionString = expressionString.replaceAll(String.format("\\(\\(var %s\\)\\)", variableName),

--- a/src/main/scala/org/allenai/pnp/semparse/SemanticParserUtils.scala
+++ b/src/main/scala/org/allenai/pnp/semparse/SemanticParserUtils.scala
@@ -151,7 +151,7 @@ object SemanticParserUtils {
         numFailed += 1
       }
     }
-    println("max parts: " + maxParts)
+    println("max templates in a correct logical form: " + maxParts)
     println("decoding failures: " + numFailed)
     
     val holeTypes = usedRules.map(_._1).toSet

--- a/src/main/scala/org/allenai/wikitables/WikiTablesSemanticParserCli.scala
+++ b/src/main/scala/org/allenai/wikitables/WikiTablesSemanticParserCli.scala
@@ -56,13 +56,20 @@ class WikiTablesSemanticParserCli extends AbstractCli() {
   var derivationsPathOpt: OptionSpec[String] = null
   var modelOutputOpt: OptionSpec[String] = null
   
+  var maxDerivationsOpt: OptionSpec[Integer] = null
+  var epochsOpt: OptionSpec[Integer] = null
+  var beamSizeOpt: OptionSpec[Integer] = null
+  
   var skipActionSpaceValidationOpt: OptionSpec[Void] = null
 
   override def initializeOptions(parser: OptionParser): Unit = {
     trainingDataOpt = parser.accepts("trainingData").withRequiredArg().ofType(classOf[String]).withValuesSeparatedBy(',').required()
     derivationsPathOpt = parser.accepts("derivationsPath").withRequiredArg().ofType(classOf[String])
-
     modelOutputOpt = parser.accepts("modelOut").withRequiredArg().ofType(classOf[String]).required()
+    
+    maxDerivationsOpt = parser.accepts("maxDerivations").withRequiredArg().ofType(classOf[Integer]).defaultsTo(1)
+    epochsOpt = parser.accepts("epochs").withRequiredArg().ofType(classOf[Integer]).defaultsTo(50)
+    beamSizeOpt = parser.accepts("beamSize").withRequiredArg().ofType(classOf[Integer]).defaultsTo(5)
     
     skipActionSpaceValidationOpt = parser.accepts("skipActionSpaceValidation")
   }
@@ -79,21 +86,27 @@ class WikiTablesSemanticParserCli extends AbstractCli() {
     // Read and preprocess data
     val trainingData = ListBuffer[CustomExample]()
     for (filename <- options.valuesOf(trainingDataOpt).asScala) {
-      trainingData ++= WikiTablesDataProcessor.getDataset(filename, true, true, options.valueOf(derivationsPathOpt), 100, 50).asScala
+      trainingData ++= WikiTablesDataProcessor.getDataset(filename, true, true,
+          options.valueOf(derivationsPathOpt), 100,
+          options.valueOf(maxDerivationsOpt)).asScala
+    }
+    
+    for (ex <- trainingData) {
+      println(ex.getTokens)
+      println(ex.alternativeFormulas)
     }
 
     println("Read " + trainingData.size + " training examples")
-    val wordCounts = getWordCounts(trainingData)
+    val wordCounts = getTokenCounts(trainingData)
     val allEntities = trainingData.map(ex => getUnlinkedEntities(ex)).flatten.toList
-    val entityCounts = getEntityCounts(allEntities)
+    val entityCounts = getEntityTokenCounts(allEntities)
     // Vocab consists of all words that appear more than once in
-    // the training data.
+    // the training data and in the name of any entity.
     val vocab = IndexedList.create(wordCounts.getKeysAboveCountThreshold(1.9))
     vocab.addAll(IndexedList.create(entityCounts.getKeysAboveCountThreshold(0.0)))
     vocab.add(UNK)
     vocab.add(ENTITY)
-    println(vocab.size + " words")
-    
+    println(vocab.size + " words")    
 
     // Eliminate those examples that Sempre did not find correct logical forms for.
     val trainPreprocessed = trainingData.filter(!_.alternativeFormulas.isEmpty).map(
@@ -151,7 +164,8 @@ class WikiTablesSemanticParserCli extends AbstractCli() {
       println("Skipping action space validation")
     }
 
-    val trainedModel = train(trainPreprocessed, parser, typeDeclaration)
+    val trainedModel = train(trainPreprocessed, parser, typeDeclaration,
+        options.valueOf(epochsOpt), options.valueOf(beamSizeOpt))
     
     // TODO: serialization
     val saver = new ModelSaver(options.valueOf(modelOutputOpt))
@@ -170,7 +184,7 @@ object WikiTablesSemanticParserCli {
     (new WikiTablesSemanticParserCli()).run(args)
   }
 
-  def getWordCounts(examples: Seq[CustomExample]): CountAccumulator[String] = {
+  def getTokenCounts(examples: Seq[CustomExample]): CountAccumulator[String] = {
     val acc = CountAccumulator.create[String]
     for (ex <- examples) {
       ex.getTokens.asScala.map(x => acc.increment(x, 1.0)) 
@@ -178,13 +192,10 @@ object WikiTablesSemanticParserCli {
     acc
   }
 
-  def getEntityCounts(entityNames: List[String]): CountAccumulator[String] = {
+  def getEntityTokenCounts(entityNames: List[String]): CountAccumulator[String] = {
     val acc = CountAccumulator.create[String]
     for (entityString <- entityNames) {
-      // Strings are of the form fb:cell.cell_name
-      val parts = entityString.split('.')
-      acc.increment(parts.slice(1, parts.size - 1).mkString("."), 1.0)  // entity type
-      parts.last.split('_').map(x => acc.increment(x, 1.0))  // actual value split into tokens
+      tokenizeEntity(entityString).map(x => acc.increment(x, 1.0))
     }
     acc
   }
@@ -213,7 +224,7 @@ object WikiTablesSemanticParserCli {
     * Returns a model with the trained parameters. 
     */
   def train(examples: Seq[WikiTablesExample], parser: SemanticParser,
-      typeDeclaration: TypeDeclaration): PnpModel = {
+      typeDeclaration: TypeDeclaration, epochs: Int, beamSize: Int): PnpModel = {
     
     parser.dropoutProb = 0.5
     val pnpExamples = for {
@@ -232,7 +243,8 @@ object WikiTablesSemanticParserCli {
     // Train model
     val model = parser.model
     val sgd = new SimpleSGDTrainer(model.model, 0.1f, 0.01f)
-    val trainer = new LoglikelihoodTrainer(20, 5, true, model, sgd, new DefaultLogFunction())
+    val trainer = new LoglikelihoodTrainer(epochs, beamSize, true, model, sgd,
+        new DefaultLogFunction())
     trainer.train(pnpExamples.toList)
 
     parser.dropoutProb = -1

--- a/src/main/scala/org/allenai/wikitables/WikiTablesSemanticParserCli.scala
+++ b/src/main/scala/org/allenai/wikitables/WikiTablesSemanticParserCli.scala
@@ -89,10 +89,6 @@ class WikiTablesSemanticParserCli extends AbstractCli() {
           100, options.valueOf(maxDerivationsOpt)).asScala
     }
 
-    for (ex <- trainingData) {
-      println(ex.getTokens)
-      println(ex.alternativeFormulas)
-    }
     println("Read " + trainingData.size + " training examples")
     val wordCounts = getTokenCounts(trainingData)
     val allEntities = trainingData.map(ex => getUnlinkedEntities(ex)).flatten.toList
@@ -110,6 +106,12 @@ class WikiTablesSemanticParserCli extends AbstractCli() {
         x => preprocessExample(x, vocab, simplifier, logicalFormParser, typeDeclaration))
     println("Found correct logical forms for " + trainPreprocessed.size + " training examples")
 
+    println("Preprocessed:")
+    for (ex <- trainPreprocessed) {
+      println(ex.getSentence.getWords)
+      println(ex.getLogicalForms)
+    }
+    
     // Generate the action space of the semantic parser from the logical
     // forms that are well-typed.
     val trainingLfs = trainPreprocessed.map(_.getLogicalForms.asScala).flatten

--- a/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
+++ b/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
@@ -3,6 +3,7 @@ package org.allenai.wikitables
 import com.jayantkrish.jklol.ccg.lambda.ExpressionParser
 import com.jayantkrish.jklol.ccg.lambda2.{Expression2, ExpressionSimplifier}
 import org.scalatest.FlatSpec
+import edu.stanford.nlp.sempre.Formula
 
 class WikiTablesUtilSpec extends FlatSpec {
 
@@ -15,5 +16,12 @@ class WikiTablesUtilSpec extends FlatSpec {
     assert(sempreExpression == expectedSempreExpression)
   }
   
-  
+  it should "convert expressions with lambdas in applications" in {
+    val e = "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda x (count (fb:row.row.computer (var x))))))"
+    val sempreLf = Formula.fromString(e)
+    val converted = WikiTablesUtil.toPnpLogicalForm(sempreLf)
+    val expected = "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda ($0) (count (fb:row.row.computer $0)))))"
+    
+    assert(converted == expected)
+  }
 }

--- a/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
+++ b/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
@@ -6,9 +6,7 @@ import org.scalatest.FlatSpec
 
 class WikiTablesUtilSpec extends FlatSpec {
 
-  behavior of "WikiTablesUtilSpec"
-
-  it should "get the right Sempre lf from PNP lf" in {
+  "WikiTablesUtil" should "get the right Sempre lf from PNP lf" in {
     val pnpExpression = ExpressionParser.expression2().parse("(lambda (y) (lambda (x) (+ x y)))")
     val simplifier = ExpressionSimplifier.lambdaCalculus()
     val pnpExpressionSimplified = simplifier.apply(pnpExpression)
@@ -16,4 +14,6 @@ class WikiTablesUtilSpec extends FlatSpec {
     val expectedSempreExpression = "(lambda x (lambda y (+ (var y) (var x))))"
     assert(sempreExpression == expectedSempreExpression)
   }
+  
+  
 }

--- a/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
+++ b/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
@@ -9,32 +9,34 @@ import edu.stanford.nlp.sempre.Formula
 class WikiTablesUtilSpec extends FlatSpec {
 
   "WikiTablesUtil" should "get the right Sempre lf from PNP lf" in {
-    val pnpExpression = ExpressionParser.expression2().parse("(lambda (y) (lambda (x) (+ x y)))")
-    val simplifier = ExpressionSimplifier.lambdaCalculus()
-    val pnpExpressionSimplified = simplifier.apply(pnpExpression)
-    val sempreExpression = WikiTablesUtil.toSempreLogicalForm(pnpExpressionSimplified)
-    val expectedSempreExpression = "(lambda x (lambda y (+ (var y) (var x))))"
-    assert(sempreExpression == expectedSempreExpression)
+    runTest("(lambda x (lambda y (+ (var x) (var y))))", "(lambda (x) (lambda (y) (+ x y)))")
   }
   
   it should "convert expressions with lambdas in applications" in {
-    val e = "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda x (count (fb:row.row.computer (var x))))))"
-    val sempreLf = Formula.fromString(e)
-    val converted = WikiTablesUtil.toPnpLogicalForm(sempreLf)
-    val expected = "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda (x) (count (fb:row.row.computer x)))))"
-    
-    assert(converted == expected)
+    runTest("(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda x (count (fb:row.row.computer (var x))))))",
+        "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda (x) (count (fb:row.row.computer x)))))")
   }
 
   it should "replace ! with reverse while converting to PNP lf" in {
     val formula = Formula.fromString("(!fb:row.row.score (fb:row.row.opponent (or fb:cell.vs_bc_lions fb:cell.at_bc_lions)))")
     val expectedPnpLf = "((reverse fb:row.row.score) (fb:row.row.opponent (or fb:cell.vs_bc_lions fb:cell.at_bc_lions)))"
-    assert(expectedPnpLf == WikiTablesUtil.toPnpLogicalForm(formula))
+    assert(expectedPnpLf == WikiTablesUtil.toPnpLogicalForm(formula).toString)
   }
 
   it should "not replace ! with reverse in != while converting to PNP lf" in {
     val formula = Formula.fromString("(!= fb:cell.ulm)")
     val expectedPnpLf = "(!= fb:cell.ulm)"
-    assert(expectedPnpLf == WikiTablesUtil.toPnpLogicalForm(formula))
+    assert(expectedPnpLf == WikiTablesUtil.toPnpLogicalForm(formula).toString)
+  }
+  
+  def runTest(sempre: String, pnp: String): Unit = {
+    val pnpExpression = ExpressionParser.expression2().parse(pnp)
+    val sempreFormula = Formula.fromString(sempre)
+
+    val pnpToSempre = WikiTablesUtil.toSempreLogicalForm(pnpExpression)
+    assert(pnpToSempre.toString == sempre)
+
+    val sempreToPnp = WikiTablesUtil.toPnpLogicalForm(sempreFormula)
+    assert(sempreToPnp.toString == pnp)
   }
 }

--- a/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
+++ b/src/test/scala/org/allenai/wikitables/WikiTablesUtilSpec.scala
@@ -21,7 +21,7 @@ class WikiTablesUtilSpec extends FlatSpec {
     val e = "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda x (count (fb:row.row.computer (var x))))))"
     val sempreLf = Formula.fromString(e)
     val converted = WikiTablesUtil.toPnpLogicalForm(sempreLf)
-    val expected = "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda ($0) (count (fb:row.row.computer $0)))))"
+    val expected = "(argmax (number 1) (number 1) (fb:cell.cell.part (!= fb:part.gamecube)) (reverse (lambda (x) (count (fb:row.row.computer x)))))"
     
     assert(converted == expected)
   }


### PR DESCRIPTION
Fixing random bugs in parser training. I discovered that the execution of sempre logical forms currently does not give us correct answers for logical forms in the DPD output. I added a workaround to this problem in parser evaluation that checks if the predicted logical forms is in the DPD output.

These changes get us to an oracle@5 training accuracy of 82%, which is the best we can do on the training set given the current parser's action space.