### PR TITLE
Limit derivations after loading preprocessed files

### DIFF
--- a/src/main/scala/org/allenai/wikitables/TestWikiTablesCli.scala
+++ b/src/main/scala/org/allenai/wikitables/TestWikiTablesCli.scala
@@ -62,7 +62,7 @@ class TestWikiTablesCli extends AbstractCli() {
 
     // Read test data.
     val testData = WikiTablesUtil.loadDatasets(options.valuesOf(testDataOpt).asScala,
-        true, options.valueOf(derivationsPathOpt), options.valueOf(maxDerivationsOpt))
+        options.valueOf(derivationsPathOpt), options.valueOf(maxDerivationsOpt))
     println("Read " + testData.size + " test examples")
 
     testData.foreach(x => WikiTablesUtil.preprocessExample(x, parser.vocab,

--- a/src/main/scala/org/allenai/wikitables/WikiTablesSemanticParserCli.scala
+++ b/src/main/scala/org/allenai/wikitables/WikiTablesSemanticParserCli.scala
@@ -105,7 +105,7 @@ class WikiTablesSemanticParserCli extends AbstractCli() {
     // Read and preprocess data
     val includeDerivationsForTrain = !options.has(trainOnAnnotatedLfsOpt)
     val trainingData = loadDatasets(options.valuesOf(trainingDataOpt).asScala,
-        includeDerivationsForTrain, options.valueOf(derivationsPathOpt),
+        options.valueOf(derivationsPathOpt),
         options.valueOf(maxDerivationsOpt))
     
     println("Read " + trainingData.size + " training examples")
@@ -128,7 +128,7 @@ class WikiTablesSemanticParserCli extends AbstractCli() {
 
   def initializeDevelopmentData(options: OptionSet, featureGen: SemanticParserFeatureGenerator,
       vocab: IndexedList[String]): Seq[WikiTablesExample] = {
-    val devData = loadDatasets(options.valuesOf(devDataOpt).asScala,  false, null, 0)
+    val devData = loadDatasets(options.valuesOf(devDataOpt).asScala, null, -1)
     println("Read " + devData.size + " development examples")
 
     devData.foreach(x => WikiTablesUtil.preprocessExample(x, vocab, featureGen, typeDeclaration))


### PR DESCRIPTION
@jayantk As discussed, this limits the number of possible LFs after loading from json so we don't have to redo preprocessing if changing those parameters.

Note that the `val includeDerivationsForTrain = !options.has(trainOnAnnotatedLfsOpt)` parameter is now unused, so if that's a parameter we think of using, does it map into setting number of derivations to 0 or something like that?