### PR TITLE
Add token overlap features

### DIFF
--- a/src/main/scala/org/allenai/wikitables/SemanticParserFeatureGenerator.scala
+++ b/src/main/scala/org/allenai/wikitables/SemanticParserFeatureGenerator.scala
@@ -12,17 +12,25 @@ import org.allenai.pnp.semparse.EntityLinking
 import com.google.common.base.Preconditions
 import com.jayantkrish.jklol.util.IndexedList
 
-class SemanticParserFeatureGenerator(featureFunctions: Array[EntityTokenFeatureFunction]) 
- extends Serializable {
+import scala.collection.mutable
 
-  val numFeatures = featureFunctions.size
-  
+class SemanticParserFeatureGenerator(
+  featureFunctions: Array[EntityTokenFeatureFunction],
+  featureFunctionsPrecomputed: Array[EntityTokenFeaturePrecomputeFunction]
+)
+    extends Serializable {
+
+  val numFeatures = featureFunctions.size + featureFunctionsPrecomputed.size
+
   def apply(example: WikiTablesExample, entity: Entity, span: Option[Span],
-      tokenToId: String => Int, table: Table): (Dim, FloatVector) = {
+    tokenToId: String => Int, table: Table): (Dim, FloatVector) = {
     // A tokens x features matrix.
     val tokens = example.sentence.getWords.asScala
     val dim = Dim(tokens.size, numFeatures)
     val matrix = new FloatVector(tokens.size * numFeatures)
+    val featuresPrecomputed = for (featureFunc <- featureFunctionsPrecomputed) yield {
+      featureFunc(example, entity, span, tokenToId, table)
+    }
     for (i <- 0 until tokens.length) {
       for ((featureFunc, j) <- featureFunctions.zipWithIndex) {
         // Dynet stores matrices in column-major format,
@@ -30,6 +38,12 @@ class SemanticParserFeatureGenerator(featureFunctions: Array[EntityTokenFeatureF
         // each feature are consecutive).
         val index = j * tokens.size + i
         val featureValue = featureFunc(example, i, entity, span, tokenToId, table)
+        matrix(index) = featureValue
+      }
+      for (k <- featuresPrecomputed.indices) {
+        val j = k + featureFunctions.size
+        val index = j * tokens.size + i
+        val featureValue = featuresPrecomputed(k)(i)
         matrix(index) = featureValue
       }
     }
@@ -40,24 +54,32 @@ class SemanticParserFeatureGenerator(featureFunctions: Array[EntityTokenFeatureF
 object SemanticParserFeatureGenerator {
   type EntityTokenFeatureFunction = (WikiTablesExample, Int, Entity, Option[Span], String => Int, Table) => Float
 
+  type EntityTokenFeaturePrecomputeFunction = (WikiTablesExample, Entity, Option[Span], String => Int, Table) => Seq[Float]
+
   def getWikitablesGenerator(editDistance: Boolean): SemanticParserFeatureGenerator = {
     var features: List[EntityTokenFeatureFunction] = List(
-        SemanticParserFeatureGenerator.spanFeatures,
-        SemanticParserFeatureGenerator.tokenExactMatchFeature,
-        SemanticParserFeatureGenerator.tokenLemmaMatchFeature,
-        // SemanticParserFeatureGenerator.editDistanceFeature,
-        SemanticParserFeatureGenerator.relatedColumnFeature,
-        SemanticParserFeatureGenerator.relatedColumnLemmaFeature)
-        
-     if (editDistance) {
-       features = features ++ List(SemanticParserFeatureGenerator.editDistanceFeature _)
-     }
+      SemanticParserFeatureGenerator.spanFeatures,
+      SemanticParserFeatureGenerator.tokenExactMatchFeature,
+      SemanticParserFeatureGenerator.tokenLemmaMatchFeature,
+      // SemanticParserFeatureGenerator.editDistanceFeature,
+      SemanticParserFeatureGenerator.relatedColumnFeature,
+      SemanticParserFeatureGenerator.relatedColumnLemmaFeature
+    )
 
-    new SemanticParserFeatureGenerator(features.toArray)
+    if (editDistance) {
+      features = features ++ List(SemanticParserFeatureGenerator.editDistanceFeature _)
+    }
+
+    var featuresWithPrecompute: List[EntityTokenFeaturePrecomputeFunction] = List(
+      SemanticParserFeatureGenerator.entityTokenSpanOverlapFeatures,
+      SemanticParserFeatureGenerator.entityTokenSpanOverlapLemmaFeatures
+    )
+
+    new SemanticParserFeatureGenerator(features.toArray, featuresWithPrecompute.toArray)
   }
-  
+
   def spanFeatures(ex: WikiTablesExample, tokenIndex: Int, entity: Entity,
-      span: Option[Span], tokenToId: String => Int, table: Table): Float = {
+    span: Option[Span], tokenToId: String => Int, table: Table): Float = {
     if (span.isDefined && span.get.contains(tokenIndex)) {
       1.0f
     } else {
@@ -66,7 +88,7 @@ object SemanticParserFeatureGenerator {
   }
 
   def tokenExactMatchFeature(ex: WikiTablesExample, tokenIndex: Int, entity: Entity,
-      span: Option[Span], tokenToId: String => Int, table: Table): Float = {
+    span: Option[Span], tokenToId: String => Int, table: Table): Float = {
     val token = ex.sentence.getWords.get(tokenIndex)
     if (entity.nameTokensSet.contains(tokenToId(token))) {
       1.0f
@@ -74,9 +96,9 @@ object SemanticParserFeatureGenerator {
       0.0f
     }
   }
-  
+
   def tokenLemmaMatchFeature(ex: WikiTablesExample, tokenIndex: Int, entity: Entity,
-      span: Option[Span], tokenToId: String => Int, table: Table): Float = {
+    span: Option[Span], tokenToId: String => Int, table: Table): Float = {
     val token = ex.sentence.getWords.get(tokenIndex)
     val lemmas = ex.sentence.getAnnotation(WikiTablesUtil.LEMMA_ANNOTATION).asInstanceOf[List[String]]
     val lemma = lemmas(tokenIndex)
@@ -88,7 +110,7 @@ object SemanticParserFeatureGenerator {
   }
 
   def editDistanceFeature(ex: WikiTablesExample, tokenIndex: Int, entity: Entity,
-      span: Option[Span], tokenToId: String => Int, table: Table): Float = { 
+    span: Option[Span], tokenToId: String => Int, table: Table): Float = {
     // Note that the returned value is <= 1.0 and can be negative if the edit distance is greater
     // than the length of the token.
     // Assuming entity string is a constant.
@@ -96,9 +118,9 @@ object SemanticParserFeatureGenerator {
     val entityString = entity.expr.toString.split("\\.").last
     1.0f - (StringUtils.getLevenshteinDistance(token, entityString).toFloat / token.length)
   }
-  
+
   def relatedColumnFeature(ex: WikiTablesExample, tokenIndex: Int, entity: Entity,
-      span: Option[Span], tokenToId: String => Int, table: Table): Float = {
+    span: Option[Span], tokenToId: String => Int, table: Table): Float = {
     val token = ex.sentence.getWords.get(tokenIndex)
     if (entity.t == WikiTablesTypeDeclaration.COL_FUNCTION_TYPE) {
       val id = entity.expr.toString
@@ -119,7 +141,7 @@ object SemanticParserFeatureGenerator {
   }
 
   def relatedColumnLemmaFeature(ex: WikiTablesExample, tokenIndex: Int, entity: Entity,
-      span: Option[Span], tokenToId: String => Int, table: Table): Float = {
+    span: Option[Span], tokenToId: String => Int, table: Table): Float = {
     val token = ex.sentence.getWords.get(tokenIndex)
     val lemmas = ex.sentence.getAnnotation(WikiTablesUtil.LEMMA_ANNOTATION).asInstanceOf[List[String]]
     val lemma = lemmas(tokenIndex)
@@ -140,4 +162,40 @@ object SemanticParserFeatureGenerator {
       0.0f
     }
   }
+
+  // Going left to right, find maximal contiguous sequence of elements in sequence which is in
+  // set and score each element according to overlap fraction. E.g.,
+  // maxOverlapFractions(Seq(1,2,3,2,5,2,4), Set(1,2,3,4)) =
+  //   Seq(0.75, 0.75, 0.75, 0.5, 0.0, 0.5, 0.5)
+  def maxOverlapFractions[A](sequence: Seq[A], set: Set[A]): Seq[Float] = {
+    val setSize = set.size
+    var stopIndex = 0
+    val res = mutable.Seq.fill(sequence.size)(0f)
+    for (startIndex <- sequence.indices) {
+      if (stopIndex < startIndex) stopIndex = startIndex
+      while (stopIndex < sequence.size && set.contains(sequence(stopIndex)) &&
+        !sequence.slice(startIndex, stopIndex).contains(sequence(stopIndex))) {
+        stopIndex += 1
+      }
+      val score = 1.0f * (stopIndex - startIndex) / setSize
+      for (i <- startIndex until stopIndex) {
+        res(i) = score.max(res(i))
+      }
+    }
+    res
+  }
+
+  def entityTokenSpanOverlapFeatures(ex: WikiTablesExample, entity: Entity,
+    span: Option[Span], tokenToId: String => Int, table: Table): Seq[Float] = {
+    val tokenIds = ex.sentence.getWords.asScala.map(tokenToId)
+    maxOverlapFractions(tokenIds, entity.nameTokensSet)
+  }
+
+  def entityTokenSpanOverlapLemmaFeatures(ex: WikiTablesExample, entity: Entity,
+    span: Option[Span], tokenToId: String => Int, table: Table): Seq[Float] = {
+    val tokenLemmas =
+      ex.sentence.getAnnotation(WikiTablesUtil.LEMMA_ANNOTATION).asInstanceOf[Seq[String]]
+    maxOverlapFractions(tokenLemmas, entity.nameLemmaSet)
+  }
+
 }

--- a/src/main/scala/org/allenai/wikitables/WikiTablesUtil.scala
+++ b/src/main/scala/org/allenai/wikitables/WikiTablesUtil.scala
@@ -198,7 +198,8 @@ object WikiTablesUtil {
     acc
   }
 
-  def computeVocabulary(trainingDataWithEntities: Seq[RawExample], threshold: Int) = {
+  def computeVocabulary(trainingDataWithEntities: Seq[RawExample],
+      threshold: Int): (IndexedList[String], Array[Double]) = {
     val wordCounts = getTokenCounts(trainingDataWithEntities.map(_.ex))
     val entityCounts = getEntityTokenCounts(trainingDataWithEntities)
     // Vocab consists of all words that appear more than once in
@@ -214,7 +215,7 @@ object WikiTablesUtil {
     for (w <- vocab.items().asScala.sorted) {
       println("  " + w + " " + wordCounts.getCount(w) + " " + entityCounts.getCount(w))
     }
-    vocab
+    (vocab, vocab.items.asScala.map(w => wordCounts.getCount(w) + entityCounts.getCount(w)).toArray)
   }
 
   /** Returns a modified dataset that has CcgExamples, with one logical form per example.


### PR DESCRIPTION
@jayantk This adds two features for matching question tokens against entities. 

The first feature (`entityTokenSpanOverlapFeatures`) looks for contiguous spans of question tokens which exactly match any token in the entity. It disregards entity tokens which are not alphanumeric. Each match is penalized by word count across training examples (questions and tables) (`weight = 1/log(count + 5)` where `5` is a smoothing parameter) and the final value is coverage between 0 and 1.

The second feature is similar, except it also allows matching on the lemma in addition to the exact text. The scoring is still as before (on the unlemmatized version) which can in rare cases lead to values > 1. 

I don't see conclusive increases in validation scores after adding these features, I'm getting scores around 40% (+- 1%) with or without this (the earlier runs using `MAX_TRAINING_DERIVATIONS` of 100, the later ones 10, but it takes just as long to run so I'm guessing this doesn't matter much).